### PR TITLE
Cache: Rebuild package store (cache.bin) on configured period of time

### DIFF
--- a/samples/NuGet.Server.V2.Samples.OwinHost/DictionarySettingsProvider.cs
+++ b/samples/NuGet.Server.V2.Samples.OwinHost/DictionarySettingsProvider.cs
@@ -7,9 +7,9 @@ namespace NuGet.Server.V2.Samples.OwinHost
 {
     public class DictionarySettingsProvider : ISettingsProvider
     {
-        readonly Dictionary<string, bool> _settings;
+        readonly Dictionary<string, object> _settings;
 
-        public DictionarySettingsProvider(Dictionary<string, bool> settings)
+        public DictionarySettingsProvider(Dictionary<string, object> settings)
         {
             _settings = settings;
         }
@@ -18,8 +18,14 @@ namespace NuGet.Server.V2.Samples.OwinHost
         public bool GetBoolSetting(string key, bool defaultValue)
         {
             System.Diagnostics.Debug.WriteLine("getSetting: " + key);
-            return _settings.ContainsKey(key) ? _settings[key] : defaultValue;
+            return _settings.ContainsKey(key) && _settings[key] is bool ? 
+                (bool)_settings[key] : defaultValue;
+        }
 
+        public int GetIntSetting(string key, int defaultValue)
+        {
+            System.Diagnostics.Debug.WriteLine("getSetting: " + key);
+            return _settings.ContainsKey(key) && _settings[key] is int ? (int)_settings[key] : defaultValue;
         }
     }
 }

--- a/samples/NuGet.Server.V2.Samples.OwinHost/Program.cs
+++ b/samples/NuGet.Server.V2.Samples.OwinHost/Program.cs
@@ -24,11 +24,13 @@ namespace NuGet.Server.V2.Samples.OwinHost
 
             // Set up a common settingsProvider to be used by all repositories. 
             // If a setting is not present in dictionary default value will be used.
-            var settings = new Dictionary<string, bool>();
+            var settings = new Dictionary<string, object>();
             settings.Add("enableDelisting", false);                         //default=false
             settings.Add("enableFrameworkFiltering", false);                //default=false
             settings.Add("ignoreSymbolsPackages", true);                    //default=false
             settings.Add("allowOverrideExistingPackageOnPush", true);       //default=true
+            settings.Add("packageStoreRebuildMinutesPeriod", 60);                    //default=60
+           
             var settingsProvider = new DictionarySettingsProvider(settings);
 
             var logger = new ConsoleLogger();

--- a/src/NuGet.Server.Core/Infrastructure/DefaultSettingsProvider.cs
+++ b/src/NuGet.Server.Core/Infrastructure/DefaultSettingsProvider.cs
@@ -8,5 +8,10 @@ namespace NuGet.Server.Core.Infrastructure
         {
             return defaultValue;
         }
+
+        public int GetIntSetting(string key, int defaultValue)
+        {
+            return defaultValue;
+        }
     }
 }

--- a/src/NuGet.Server.Core/Infrastructure/ISettingsProvider.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ISettingsProvider.cs
@@ -5,5 +5,7 @@ namespace NuGet.Server.Core.Infrastructure
     public interface ISettingsProvider
     {
         bool GetBoolSetting(string key, bool defaultValue);
+
+        int GetIntSetting(string key, int defaultValue);
     }
 }

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -93,10 +93,9 @@ namespace NuGet.Server.Core.Infrastructure
             _persistenceTimer = new Timer(state =>
                 _serverPackageStore.PersistIfDirty(), null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
 
-            // Rebuild the package store in the background (every hour)
+            // Rebuild the package store in the background (every hour by default)
             _rebuildTimer = new Timer(state =>
-                RebuildPackageStore(), null, TimeSpan.FromSeconds(15), TimeSpan.FromHours(1));
-
+                RebuildPackageStore(), null, TimeSpan.FromSeconds(15), PackageStoreRebuildTimeSpan);
             _logger.Log(LogLevel.Info, "Finished registering background jobs.");
         }
 
@@ -721,6 +720,13 @@ namespace NuGet.Server.Core.Infrastructure
                 return _settingsProvider.GetBoolSetting("enableFileSystemMonitoring", true);
             }
         }
+        
+        /// <summary>
+        /// The time period to execute a background job which rebuilds the Package Store
+        /// </summary>
+        private int PackageStoreRebuildMinutesPeriod => _settingsProvider.GetIntSetting("packageStoreRebuildMinutesPeriod", 60);
+
+        private TimeSpan PackageStoreRebuildTimeSpan => TimeSpan.FromMinutes(PackageStoreRebuildMinutesPeriod);
 
         private string GetPackageFileName(string packageId, SemanticVersion version)
         {

--- a/src/NuGet.Server/Infrastructure/WebConfigSettingsProvider.cs
+++ b/src/NuGet.Server/Infrastructure/WebConfigSettingsProvider.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
-using System;
+
 using System.Web.Configuration;
 using NuGet.Server.Core.Infrastructure;
 
@@ -11,8 +11,13 @@ namespace NuGet.Server.Infrastructure
         public bool GetBoolSetting(string key, bool defaultValue)
         {
             var appSettings = WebConfigurationManager.AppSettings;
-            bool value;
-            return !Boolean.TryParse(appSettings[key], out value) ? defaultValue : value;
+            return !bool.TryParse(appSettings[key], out var value) ? defaultValue : value;
+        }
+
+        public int GetIntSetting(string key, int defaultValue)
+        {
+            var appSettings = WebConfigurationManager.AppSettings;
+            return !int.TryParse(appSettings[key], out var value) ? defaultValue : value;
         }
     }
 }

--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -56,6 +56,12 @@
     on a fixed 1-hour interval.
     -->
     <add key="enableFileSystemMonitoring" value="true" />
+
+    <!--
+    Set packageStoreRebuildMinutesPeriod to a minute interval(default is 60 minutes) in which the package store will be rebuilt by a background job. 
+    -->
+    <add key="packageStoreRebuildMinutesPeriod" value="60" />
+
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/test/NuGet.Server.Core.Tests/Infrastructure/FuncSettingsProvider.cs
+++ b/test/NuGet.Server.Core.Tests/Infrastructure/FuncSettingsProvider.cs
@@ -8,19 +8,32 @@ namespace NuGet.Server.Core.Tests.Infrastructure
     class FuncSettingsProvider : ISettingsProvider
     {
         readonly Func<string, bool, bool> _getSetting;
-        internal FuncSettingsProvider(Func<string,bool,bool> getSetting)
+        readonly Func<string, int, int> _getIntSetting;
+
+        internal FuncSettingsProvider(Func<string,bool,bool> getSetting, Func<string, int, int> getIntSetting)
         {
             if (getSetting == null)
             {
                 throw new ArgumentNullException(nameof(getSetting));
             }
 
+            if (getIntSetting == null)
+            {
+                throw new ArgumentNullException(nameof(getIntSetting));
+            }
+
             _getSetting = getSetting;
+            _getIntSetting = getIntSetting;
         }
 
         public bool GetBoolSetting(string key, bool defaultValue)
         {
             return _getSetting(key, defaultValue);
+        }
+
+        public int GetIntSetting(string key, int defaultValue)
+        {
+            return _getIntSetting(key, defaultValue);
         }
     }
 }

--- a/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
+++ b/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
@@ -14,7 +14,8 @@ namespace NuGet.Server.Core.Tests
 {
     public class ServerPackageRepositoryTest
     {
-        public static ServerPackageRepository CreateServerPackageRepository(string path, Action<ExpandedPackageRepository> setupRepository = null, Func<string, bool, bool> getSetting = null)
+        public static ServerPackageRepository CreateServerPackageRepository(string path, Action<ExpandedPackageRepository> setupRepository = null, 
+            Func<string, bool, bool> getSetting = null, Func<string, int, int> intSettings = null)
         {
             var fileSystem = new PhysicalFileSystem(path);
             var expandedPackageRepository = new ExpandedPackageRepository(fileSystem);
@@ -29,7 +30,7 @@ namespace NuGet.Server.Core.Tests
                 runBackgroundTasks: false,
                 innerRepository: expandedPackageRepository,
                 logger: new Infrastructure.NullLogger(),
-                settingsProvider: getSetting != null ? new FuncSettingsProvider(getSetting) : null);
+                settingsProvider: getSetting != null && intSettings != null ? new FuncSettingsProvider(getSetting, intSettings) : null);
 
             serverRepository.GetPackages(); // caches the files
 
@@ -162,10 +163,12 @@ namespace NuGet.Server.Core.Tests
                     return defaultValue;
                 };
 
+                Func<string, int, int> getIntSetting = (key, defaultValue) => defaultValue;
+
                 var serverRepository = CreateServerPackageRepository(temporaryDirectory.Path, repository =>
                 {
                     repository.AddPackage(CreatePackage("test1", "1.0"));
-                }, getSetting);
+                }, getSetting, getIntSetting);
 
                 // Assert base setup
                 var packages = serverRepository.Search("test1", true).ToList();


### PR DESCRIPTION
Added a new key to support configuration of package store rebuild background job.
Change ISettingsProvider to support int values
